### PR TITLE
ci: rebuild daily to pick up new Medium posts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
       - master
       - main
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'   # daily at 06:00 UTC; rebuilds to re-fetch Medium feed
 
 permissions:
   contents: write


### PR DESCRIPTION
Add a cron schedule so the deploy workflow re-fetches the Medium RSS feed on its own, instead of only on push/PR/manual dispatch.