### PR TITLE
feat: cross-post Substack alongside Medium in blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,8 @@ disqus_shortname: al-folio # put your disqus shortname
 external_sources:
   - name: medium.com
     rss_url: https://medium.com/@georgioszefkilis/feed
+  - name: substack.com
+    rss_url: https://georgioszefkilis.substack.com/feed
 
 # -----------------------------------------------------------------------------
 # Collections

--- a/_plugins/external-posts.rb
+++ b/_plugins/external-posts.rb
@@ -9,6 +9,9 @@ module ExternalPosts
 
     def generate(site)
       if site.config['external_sources'] != nil
+        # ponytail: cross-posts share a title -> first source wins as the main
+        # entry; later sources with the same slug become "alt_sources" links.
+        docs_by_slug = {}
         site.config['external_sources'].each do |src|
           p "Fetching external posts from #{src['name']}:"
           xml = HTTParty.get(src['rss_url']).body
@@ -16,6 +19,12 @@ module ExternalPosts
           feed.entries.each do |e|
             p "...fetching #{e.url}"
             slug = e.title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+            if docs_by_slug.key?(slug)
+              existing = docs_by_slug[slug]
+              existing.data['alt_sources'] ||= []
+              existing.data['alt_sources'] << { 'name' => src['name'], 'url' => e.url }
+              next
+            end
             path = site.in_source_dir("_posts/#{slug}.md")
             doc = Jekyll::Document.new(
               path, { :site => site, :collection => site.collections['posts'] }
@@ -27,6 +36,7 @@ module ExternalPosts
             doc.data['date'] = e.published;
             doc.data['redirect'] = e.url;
             site.collections['posts'].docs << doc
+            docs_by_slug[slug] = doc
           end
         end
       end

--- a/blog/index.html
+++ b/blog/index.html
@@ -128,7 +128,12 @@ pagination:
         {{ read_time }} min read &nbsp; &middot; &nbsp;
         {{ post.date | date: '%B %-d, %Y' }}
         {%- if post.external_source %}
-        &nbsp; &middot; &nbsp; {{ post.external_source }}
+        &nbsp; &middot; &nbsp; <a href="{{ post.redirect }}" target="_blank">{{ post.external_source }}</a>
+        {%- endif %}
+        {%- if post.alt_sources %}
+          {%- for alt in post.alt_sources %}
+          &nbsp; &middot; &nbsp; <a href="{{ alt.url }}" target="_blank">{{ alt.name }}</a>
+          {%- endfor %}
         {%- endif %}
       </p>
       <p class="post-tags">


### PR DESCRIPTION
Add Substack as a second external source. The plugin now dedupes cross-posted articles by title slug (first source wins as the main entry) and exposes the others as alt_sources, so the blog list links each post to Medium with a secondary "open on Substack" link.